### PR TITLE
Refactor Trading Menu and child Pages

### DIFF
--- a/apps/client/src/app/app.tsx
+++ b/apps/client/src/app/app.tsx
@@ -3,8 +3,8 @@ import { Route, Routes, useLocation } from 'react-router-dom';
 import { Toaster } from '@erisfy/shadcnui';
 import { navigationConfig } from './constants/navigationConfig';
 import { ErrorBoundary } from './components/ErrorBoundary';
-import { StockScreenerPage } from './pages/stock-screener/StockScreener';
-import { StockProfilePage } from './pages/stock-profile/StockProfile';
+import { ScreenerResultsPage } from './pages/screener-results/ScreenerResults';
+import { StockDetailPage } from './pages/stock-detail/StockDetail';
 
 const App: FC = () => {
   const location = useLocation();
@@ -33,18 +33,18 @@ const App: FC = () => {
           />
         ))}
         <Route
-          path="/trading/stock-screener"
+          path="/screener/results"
           element={
             <ErrorBoundary>
-              <StockScreenerPage />
+              <ScreenerResultsPage />
             </ErrorBoundary>
           }
         />
         <Route
-          path="/trading/stock-profile/:ticker"
+          path="/screener/stock-detail/:ticker"
           element={
             <ErrorBoundary>
-              <StockProfilePage />
+              <StockDetailPage />
             </ErrorBoundary>
           }
         />

--- a/apps/client/src/app/constants/navigationConfig.ts
+++ b/apps/client/src/app/constants/navigationConfig.ts
@@ -17,8 +17,8 @@ import { NotFound } from '../pages/not-found/NotFound';
 import { PricingPage } from '../pages/pricing/Pricing';
 import { StatusBoardPage } from '../pages/status-board/StatusBoard';
 import { TermsAndConditionsPage } from '../pages/terms-and-conditions/TermsAndConditions';
-import { StockScreenerPage } from '../pages/stock-screener/StockScreener';
-import { StockProfilePage } from '../pages/stock-profile/StockProfile';
+import { ScreenerResultsPage } from '../pages/screener-results/ScreenerResults';
+import { StockDetailPage } from '../pages/stock-detail/StockDetail';
 import { MenuItem, MenubarLayout } from '@erisfy/shell';
 
 /**
@@ -41,9 +41,9 @@ const paths = {
     colorPalette: '/color-palette',
     library: '/library',
   },
-  trading: {
-    stockScreener: '/trading/stock-screener',
-    stockProfile: '/trading/stock-profile/:ticker',
+  screener: {
+    results: '/screener/results',
+    stockDetail: '/screener/stock-detail/:ticker',
   },
   notFound: '*',
 };
@@ -98,12 +98,12 @@ const sidebarData: SidebarConfiguration = {
       ],
     },
     {
-      title: 'Trading',
-      url: paths.trading.stockScreener,
+      title: 'Screener',
+      url: paths.screener.results,
       icon: Landmark,
       items: [
-        { title: 'Stock Screener', url: paths.trading.stockScreener },
-        { title: 'Stock Profile', url: paths.trading.stockProfile },
+        { title: 'Screener Results', url: paths.screener.results },
+        { title: 'Stock Detail', url: paths.screener.stockDetail },
       ],
     },
   ],
@@ -130,11 +130,11 @@ export const navigationConfig = {
   ],
   menuItems: [
     {
-      label: 'Trading',
-      path: paths.trading.stockScreener,
+      label: 'Screener',
+      path: paths.screener.results,
       children: [
-        { label: 'Stock Screener', path: paths.trading.stockScreener },
-        { label: 'Stock Profile', path: paths.trading.stockProfile },
+        { label: 'Screener Results', path: paths.screener.results },
+        { label: 'Stock Detail', path: paths.screener.stockDetail },
       ],
     },
     {
@@ -222,8 +222,8 @@ navigationConfig.routes = [
   createRoute(paths.pricing, PricingPage),
   createRoute(paths.statusBoard, StatusBoardPage),
   createRoute(paths.termsAndConditions, TermsAndConditionsPage),
-  createRoute(paths.trading.stockScreener, StockScreenerPage),
-  createRoute(paths.trading.stockProfile, StockProfilePage),
+  createRoute(paths.screener.results, ScreenerResultsPage),
+  createRoute(paths.screener.stockDetail, StockDetailPage),
   createRoute(paths.notFound, NotFound, false),
 ] as Array<{ path: string; element: React.ReactElement }>;
 

--- a/apps/client/src/app/pages/screener-results/ScreenerResults.tsx
+++ b/apps/client/src/app/pages/screener-results/ScreenerResults.tsx
@@ -6,7 +6,7 @@ import { StockFilters } from '../../components/StockFilters';
 import { SearchBar } from '../../components/SearchBar';
 import { generateMockData, StockData } from '../../utils/mockData';
 
-const StockScreenerPage: FC = () => {
+const ScreenerResultsPage: FC = () => {
 
 
   const [stocks, setStocks] = useState<StockData[]>([]);
@@ -47,7 +47,7 @@ const StockScreenerPage: FC = () => {
       <Card>
         <CardHeader>
           <CardTitle className="text-3xl font-semibold mb-2 text-primary">
-            Stock Screener Page
+            Screener Results Page
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -66,4 +66,4 @@ const StockScreenerPage: FC = () => {
   );
 };
 
-export { StockScreenerPage };
+export { ScreenerResultsPage };

--- a/apps/client/src/app/pages/stock-detail/StockDetail.tsx
+++ b/apps/client/src/app/pages/stock-detail/StockDetail.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 import { useParams } from 'react-router-dom';
 import { Card, CardHeader, CardTitle, CardContent } from '@erisfy/shadcnui';
 
-interface StockProfileProps {
+interface StockDetailProps {
   ticker: string;
   companyName: string;
   sector: string;
@@ -19,7 +19,7 @@ interface StockProfileProps {
   peRatio: number;
 }
 
-const StockProfile: FC<StockProfileProps> = ({
+const StockDetail: FC<StockDetailProps> = ({
   ticker,
   companyName,
   sector,
@@ -86,11 +86,11 @@ const StockProfile: FC<StockProfileProps> = ({
   );
 };
 
-const StockProfilePage: FC = () => {
+const StockDetailPage: FC = () => {
   const { ticker } = useParams<{ ticker: string }>();
 
   // Placeholder for fetching stock data based on the ticker
-  const stockData: StockProfileProps = {
+  const stockData: StockDetailProps = {
     ticker: 'AAPL',
     companyName: 'Apple Inc.',
     sector: 'Technology',
@@ -107,7 +107,7 @@ const StockProfilePage: FC = () => {
     peRatio: 30,
   };
 
-  return <StockProfile {...stockData} />;
+  return <StockDetail {...stockData} />;
 };
 
-export { StockProfilePage };
+export { StockDetailPage };

--- a/docs/stock screener filters.md
+++ b/docs/stock screener filters.md
@@ -1,0 +1,628 @@
+# Stock Screener
+
+## What Is Stock Screener?
+
+A Stock Screener searches through large amounts of stock data and returns a list of stocks that match one or more selected criteria - called filters.
+
+
+## Filters
+
+The list of all criteria available for screening can be accessed through the filters expand-collapse button. For a faster workflow, various combinations of filters can be saved as a preset and can be accessed from the screener's menu afterwards.
+
+### Exchange
+
+The stock exchange on which a company is listed. All stocks listed on:
+
+- National Association of Securities Dealers Automated Quotation (NASDAQ)
+- New York Stock Exchange (NYSE)
+- American Stock Exchange (AMEX)
+
+**Sorting:** No  
+**Export:** No  
+**Appearance:** Stock Detail
+
+### Index
+
+A stock's membership in a major stock exchange index such as Dow Jones Industrial or S&P 500. The stock indices track the performance of various segments of the market.
+
+**Sorting:** No  
+**Export:** No  
+**Appearance:** Stock Detail
+
+### Sector
+
+Companies are divided into several groups - sectors - according to their business activities.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Overview, Snapshot, Stock Detail
+
+### Industry
+
+Companies in a common sector are further divided by products and services into smaller groups - industries.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Overview, Snapshot, Stock Detail
+
+### Country
+
+The geographic location of a company (listed on U.S. markets). This filter includes continents, countries, or groups of countries such as Brazil + Russia + India + China (BRIC).
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Overview, Snapshot, Stock Detail
+
+### Market Cap
+
+The total dollar value of all of a company's outstanding shares. Market capitalization is a measure of corporate size.
+
+**Market Capital = Current Market Price * Number Of Shares Outstanding**  
+**Shares Outstanding = Total Number Of Shares - Shares Held In Treasury**  
+**Float = Shares Outstanding - Insider Shares - Above 5% Owners - Rule 144 Shares**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Overview, Snapshot, Stock Detail
+
+### P/E
+
+A popular valuation ratio of a company's current share price compared to its per-share earnings (trailing twelve months). Low P/E value indicates a stock is relatively cheap compared to its earnings. For instance, a P/E value of 15 means that the current price equals the sum of 15-year earnings per share. The average level varies across the market. Therefore, P/E value should be compared per sector or industry.
+
+**P/E = Current Market Price / Earnings Per Share (EPS)**  
+**P/E = Average Common Stock Price / Net Income Per Share**  
+**EPS = (Net Income - Dividends On Preferred Stock) / Average Outstanding Shares**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Fundamental, Snapshot, Stock Detail
+
+### Forward P/E
+
+A measure of the price-to-earnings ratio using forecasted earnings for the P/E calculation for the next fiscal year. If the earnings are expected to grow in the future, the forward P/E will be lower than the current P/E.
+
+**Forward P/E = Current Market Price / Forecasted Earnings Per Share**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Fundamental, Snapshot, Stock Detail
+
+### PEG
+
+A ratio used to determine a stock's value while taking into account the earnings' growth. PEG is used to measure a stock's valuation (P/E) against its projected 3-5 year growth rate. It is favored by many over the price/earnings ratio because it also takes growth into account. A lower PEG ratio indicates that a stock is undervalued.
+
+**PEG = (P/E) / Annual EPS Growth**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Fundamental, Snapshot, Stock Detail
+
+### P/S
+
+A ratio that reflects the value placed on sales by the market. It is calculated by dividing the current closing price of the stock by the dollar-sales value per share. The ratio is often used to value unprofitable companies.
+
+**P/S = Current Market Price / Total Revenues Per Share**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Fundamental, Snapshot, Stock Detail
+
+### P/B
+
+A ratio used to compare a stock's market value to its book value. It is calculated by dividing the current closing price of the stock by the latest quarter's book value per share. A lower P/B ratio could mean that the stock is either undervalued or something is fundamentally wrong with the company.
+
+**P/B = Current Market Price / (Total Assets - Total Liabilities)**  
+**P/B = Current Market Price / (Total Common Equity / Total Common Shares Outstanding)**  
+**Book Value = (Total Assets - Total Liabilities) = Share Holder's Equity**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Fundamental, Snapshot, Stock Detail
+
+### Price/Cash
+
+A ratio used to compare a stock's market value to its cash assets. It is calculated by dividing the current closing price of the stock by the latest quarter's cash per share.
+
+**P/C = Current Market Price / Cash per Share**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Fundamental, Snapshot, Stock Detail
+
+### Price/Free Cash Flow
+
+A valuation metric that compares a company's market price to its level of annual free cash flow.
+
+**P/FCF = Current Market Price / Cash Flow per Share**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Fundamental, Snapshot, Stock Detail
+
+### EPS (ttm)
+
+EPS is the portion of a company's profit allocated to each outstanding share of common stock. EPS serves as an indicator of a company's profitability and is generally considered to be the single most important variable in determining a share's price. It is also a major component of the P/E valuation ratio.
+
+**EPS = Total Earnings / Total Common Shares Outstanding (trailing twelve months)**  
+**EPS = (Net Income - Dividends On Preferred Stock) / Average Outstanding Shares**  
+**EPS Growth This Year = (EPS This Year - EPS Previous Year) / EPS Previous Year**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Fundamental, Snapshot, Stock Detail
+
+### EPS growth this fiscal year (GAAP)
+
+EPS estimate for this fiscal year.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Fundamental, Snapshot, Stock Detail
+
+### EPS growth next fiscal year (GAAP)
+
+EPS estimate for the next fiscal year.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Fundamental, Snapshot, Stock Detail
+
+### EPS growth past 5 years
+
+EPS annual growth over the past 5 fiscal years.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Fundamental, Snapshot, Stock Detail
+
+### EPS growth next 5 years
+
+EPS annual long-term estimate.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Fundamental, Snapshot, Stock Detail
+
+### EPS growth qtr over qtr
+
+EPS growth in the last quarter compared on a year-over-year basis.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Fundamental, Snapshot, Stock Detail
+
+### Sales growth qtr over qtr
+
+Company's total revenues increase in the last quarter compared on a year-over-year basis.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Snapshot, Stock Detail
+
+### Sales growth past 5 years
+
+Annual sales increase over past 5 years.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Fundamental, Stock Detail
+
+### Dividend Yield (Fiscal Year Estimate)
+
+The dividend yield equals the annual dividend per share divided by the stock’s price. This measurement tells what percentage return a company pays out to shareholders in the form of dividends. Investors who require a minimum stream of cash flow from their investment portfolio can secure this cash flow by investing in stocks paying relatively high, stable dividend yields.
+
+If there is no forward dividend estimate available, trailing twelve month (TTM) value is used.
+
+**Dividend Yield = Annual Dividend Per Share / Price Per Share**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Fundamental, Snapshot, Stock Detail
+
+### Return on Assets
+
+An indicator of how profitable a company is relative to its total assets. ROA gives an idea as to how efficient management is at using its assets to generate earnings. Calculated by dividing a company's annual earnings by its total assets, ROA is displayed as a percentage.
+
+**ROA = Annual Earnings / Total Assets**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Financial, Stock Detail
+
+### Return on Equity
+
+A measure of a corporation's profitability that reveals how much profit a company generates with the money shareholders have invested. Calculated as Net Income / Shareholder's Equity.
+
+**ROE = Annual Net Income / Share Holder's Equity**  
+**ROE = Annual Net Income / Book Value**  
+**ROE = Annual Net Income / (Total Assets - Total Liabilities)**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Financial, Stock Detail
+
+### Return on Invested Capital
+
+A financial metric used to measure a company's efficiency in allocating its capital to generate returns. It assesses how well a company is using its resources to create value for its investors. ROIC is particularly useful for evaluating a company's profitability and its ability to sustain competitive advantages over time.
+
+**ROIC = EBIT / Invested Capital**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Financial, Stock Detail
+
+### Current Ratio
+
+A liquidity ratio that measures a company's ability to pay short-term obligations. Calculated as Current Assets / Current Liabilities.
+
+**Current Ratio = Current Assets / Current Liabilities**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Financial, Stock Detail
+
+### Quick Ratio
+
+An indicator of a company's short-term liquidity. The quick ratio measures a company's ability to meet its short-term obligations with its most liquid assets. The higher the quick ratio, the better the position of the company. Calculated as (Current Assets - Inventories) / Current Liabilities.
+
+**Quick Ratio = (Current Assets - Inventories) / Current Liabilities**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Financial, Stock Detail
+
+### Long Term Debt/Equity
+
+A measure of a company's financial leverage calculated by dividing its long-term debt by stockholders' equity. It indicates what proportion of equity and debt the company is using to finance its assets.
+
+**LT Debt/Equity = Long Term Debt / (Share Holder's Equity)**  
+**LT Debt/Equity = Long Term Debt / (Total Assets - Total Liabilities)**  
+**LT Debt/Equity = Long Term Debt / (Book Value)**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Financial, Stock Detail
+
+### Debt/Equity
+
+A measure of a company's financial leverage calculated by dividing its liabilities by stockholders' equity. It indicates what proportion of equity and debt the company is using to finance its assets.
+
+**Debt/Equity = Current Liabilities / (Share Holder's Equity)**  
+**Debt/Equity = Current Liabilities / (Total Assets - Total Liabilities)**  
+**Debt/Equity = Current Liabilities / (Book Value)**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Financial, Stock Detail
+
+### Gross Margin
+
+A company's total sales revenue minus its cost of goods sold, divided by the total sales revenue, expressed as a percentage. The gross margin represents the percent of total sales revenue that the company retains after incurring the direct costs associated with producing the goods and services sold by a company. The higher the percentage, the more the company retains on each dollar of sales to service its other costs and obligations.
+
+**Gross Margin = (Total Sales - Costs) / Total Sales**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Financial, Stock Detail
+
+### Operating Margin
+
+Operating margin is a measurement of what proportion of a company's revenue is left over after paying for variable costs of production such as wages, raw materials, etc. A healthy operating margin is required for a company to be able to pay for its fixed costs, such as interest on debt. Calculated as Operating Income / Net Sales.
+
+**Operating Margin = Operating Income / Net Sales**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Financial, Stock Detail
+
+### Net Profit Margin
+
+A ratio of profitability calculated as net income divided by revenues, or net profits divided by sales. It measures how much out of every dollar of sales a company actually keeps in earnings.
+
+**Net Profit Margin = Net Income / Revenues**  
+**Net Profit Margin = Net Profits / Sales**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Financial, Stock Detail
+
+### Payout Ratio
+
+The percentage of earnings paid to shareholders in dividends.
+
+**Payout Ratio = Dividends / Earnings**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Financial, Stock Detail
+
+### Insider Ownership
+
+% of shares currently owned by company management.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Ownership, Snapshot, Stock Detail
+
+### Insider Transactions
+
+A company's shares being purchased or sold by its own management. Value represents % change in total insider ownership.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Ownership, Snapshot, Stock Detail
+
+### Institutional Ownership
+
+% of shares currently owned by institutional investors.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Ownership, Snapshot, Stock Detail
+
+### Institutional Transactions
+
+A company's shares being purchased or sold by financial institutions. Value represents % change in total institutional ownership.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Ownership, Snapshot, Stock Detail
+
+### Short Float
+
+The number of shares short divided by the total amount of shares float, expressed in %.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Ownership, Snapshot, Stock Detail
+
+### Analyst Recommendation
+
+An outlook of a stock-market analyst on a stock.
+
+**Rating Scale: 1.0 Strong Buy, 2.0 Buy, 3.0 Hold, 4.0 Sell, 5.0 Strong Sell**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Snapshot, Stock Detail
+
+### Option/Short
+
+Stocks with options and/or available to sell short.
+
+**Sorting:** No  
+**Export:** No  
+**Appearance:** Snapshot, Stock Detail
+
+### Earnings Date
+
+The company's nearest earnings-report date. The earnings reports of significant companies should also be watched carefully as they may have great influence on the stock market overall.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Financial, Snapshot, Stock Detail
+
+### Performance
+
+% Rate of return for a stock for a given time frame.
+
+**Performance values are based on the following time periods:**
+
+- Performance 1 Week = Last 5 trading days
+- Performance 1 Month = Last 21 trading days
+- Performance 3 Months = Last 63 trading days
+- Performance 6 Months = Last 126 trading days
+- Performance 1 Year = Last 252 trading days
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Performance, Snapshot, Stock Detail
+
+### Volatility
+
+A statistical measure of the dispersion of returns for a given stock. Represents average daily high/low % range.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Performance, Snapshot, Stock Detail
+
+### RSI (14)
+
+The Relative Strength Index (RSI) is a technical analysis oscillator showing price strength by comparing upward and downward close-to-close movements. It indicates oversold (buy signal) and overbought (sell signal) price levels for a given stock.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Technical, Stock Detail
+
+### Gap
+
+The difference between yesterday's closing price and today's opening price. Gaps indicate either a lack of supply (gap-up) or demand (gap-down), and usually occur after major news events.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Technical, Stock Detail
+
+### Simple Moving Average
+
+Simple Moving Average calculated as an average of the last N-periods (20-Day, 50-Day, 200-Day).
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Technical, Stock Detail
+
+### Change
+
+The percentual difference between current close and previous close price.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Technical, Stock Detail
+
+### Change from Open
+
+The percentual difference between current close and today's open price.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Technical, Stock Detail
+
+### High/Low
+
+- **Low:** Minimum of the lows during last n-periods (20-day, 50-day, 52-week).
+- **High:** Maximum of the highs during last n-periods (20-day, 50-day, 52-week).
+
+Filter options represent a percentual distance from the record high/low price.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Technical, Stock Detail
+
+### Pattern
+
+A chart pattern is a distinct formation on a stock chart that creates a trading signal, or a sign of future price movements. Chartists use these patterns to identify current trends and trend reversals and to trigger buy and sell signals.
+
+**Sorting:** No  
+**Export:** No  
+**Appearance:** Stock Detail
+
+### Candle Stick
+
+A candlestick pattern is a distinct formation of the Open, High, Low, and Close prices for given periods of time on a stock chart that creates a trading signal, or a sign of future price movements.
+
+**Sorting:** No  
+**Export:** No  
+**Appearance:** Stock Detail
+
+### Beta (5 Years)
+
+A measure of a stock's price volatility relative to the market. An asset with a beta of 0 means that its price is not at all correlated with the market. A positive beta means that the asset generally follows the market. A negative beta shows that the asset inversely follows the market, decreases in value if the market goes up.
+
+It is calculated as the slope of the 60 month regression line of the percentage price change of the stock relative to the percentage price change of the index.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Technical, Stock Detail
+
+### ATR
+
+A measure of stock volatility. The Average True Range is an exponential moving average (14-days) of the True Ranges. The range of a day's trading is high-low, True Range extends it to yesterday's closing price if it was outside of today's range.
+
+**True Range = max(high,closeprev) - min(low,closeprev)**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Technical, Stock Detail
+
+### Average Volume
+
+The average number of shares traded in a security per day, during the recent 3-month period.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Performance, Snapshot, Stock Detail
+
+### Relative Volume
+
+Ratio between current volume and 3-month average value, intraday adjusted.
+
+**Relative Volume = Current Volume / 3-month Average Volume**
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Performance, Snapshot, Stock Detail
+
+### Current Volume
+
+Total number of shares traded for a given stock today, or during the last trading session.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Performance, Snapshot, Stock Detail
+
+### Price
+
+The current stock price or the close price during the last trading session.
+
+**Sorting:** Yes  
+**Export:** Yes  
+**Appearance:** Performance, Snapshot, Stock Detail
+
+## Signals
+
+Stocks can be screened by signals - special events - on which traders usually enter or exit positions.
+
+### Top Gainers
+
+Stocks with the highest % price gain today. (Top 200 stocks)
+
+### Top Losers
+
+Stocks with the highest % price loss today. (Signal: Top 200 stocks)
+
+### New High
+
+Stocks making 52-week high today. (Signal: Top 200 stocks)
+
+### New Low
+
+Stocks making 52-week low today. (Signal: Top 200 stocks)
+
+### Most Volatile
+
+Stocks with the highest widest high/low trading range today. (Signal: Top 200 stocks)
+
+### Most Active
+
+Stocks with the highest trading volume today. (Signal: Top 200 stocks)
+
+### Unusual Volume
+
+Stocks with unusually high volume today - the highest relative volume ratio. (Signal: Top 200 stocks)
+
+### Overbought
+
+Technical analysis term for stocks with extreme price increase over past two weeks calculated by RSI(14) indicator. Generally, this means that a stock is becoming overvalued and may experience a pullback. (Signal: Top 200 stocks)
+
+### Oversold
+
+Technical analysis term for stocks with extreme price decrease over past two weeks calculated by RSI(14) indicator. Oversold stocks may represent a buying opportunity for investors. (Signal: Top 100 stocks)
+
+### Downgrades
+
+Stocks downgraded by analysts today. (Signal: All downgraded stocks)
+
+### Upgrades
+
+Stocks upgraded by analysts today. (Signal: All upgraded stocks)
+
+### Earnings Before
+
+Companies reporting earnings today, before market open. (Signal: All stocks with earnings report before today's open)
+
+### Earnings After
+
+Companies reporting earnings today, after market close. (Signal: All stocks with earnings report after today's close)
+
+### Major News
+
+Stocks with the highest news coverage today. (Signal: Top 40 stocks)
+
+### Chart Patterns
+
+Stocks with the current price near strong chart patterns. (Signal: Top 100 stocks sorted by pattern strength)
+
+## Other Data
+
+Other stock data included in the screener's views, and stock's detail.
+
+### Shares Outstanding
+
+The total number of common shares currently owned by the public.
+
+**Shares Outstanding = Total Number Of Shares - Shares Held In Treasury**
+
+### Shares Float
+
+The total number of common shares currently owned by the public and available to be traded.
+
+**Shares Float = Shares Outstanding - Insider Shares - Above 5% Owners - Rule 144 Shares**

--- a/docs/stock screener specification.md
+++ b/docs/stock screener specification.md
@@ -1,0 +1,210 @@
+# Stock Screener Specification
+
+## Overview
+
+The mockups aim to visualize a user-friendly and intuitive interface for a next-generation stock screener. The design must simplify the process of selecting and combining filters while providing actionable insights and dynamic feedback. These mockups will focus on core screens, panels, and interactive features.
+
+For detailed information on the available filters, refer to the [Stock Screener Filters](./stock%20screener%20filters.md) document.
+
+### **Implementation Context**
+
+All pages described in this document will be implemented under a drop-down "Stock Screener" menu within the application. This menu will serve as the central hub for navigating between the different features and tools of the stock screener.
+
+---
+
+## Screens and Panels
+
+### **1. Homepage/Dashboard** (Stock Screener Section)
+
+This page should be added as an option in the top-level "Stock Screener" drop-down menu.
+
+#### **Purpose**
+
+- Serve as the landing page where users start their stock screening journey.
+- Highlight filter recommendations and saved presets.
+
+#### **Key Areas**
+
+1. **Filter Library Sidebar**:
+   - Positioned on the left or as a collapsible panel.
+   - Group filters into intuitive categories (e.g., "Fundamentals," "Technicals," "Ownership," "Performance").
+   - Include a search bar at the top for quick filter lookup.
+   - "Recommended Filters" section to display AI-driven suggestions based on user goals or recent trends.
+
+2. **Main Workspace**:
+   - Large area in the center for dynamic content (e.g., results, visualizations).
+   - Includes a "Get Started" section for new users with onboarding tips and common presets.
+
+3. **Quick Actions Toolbar**:
+   - Positioned at the top or right, containing shortcuts to:
+     - Saved filters/presets.
+     - Recent searches.
+     - Help/FAQ.
+
+4. **Footer Section**:
+   - Links to additional resources like tutorials, glossary terms, and support.
+
+---
+
+### **2. Filter Selection Screen** (Stock Screener Section)
+
+This page should be added as an option in the top-level "Stock Screener" drop-down menu.
+
+#### **Purpose**
+
+- Allow users to explore and select filters interactively.
+
+#### **Key Areas**
+
+1. **Filter Category View**:
+   - Display filter categories as expandable panels or tabs.
+   - Each category should list its respective filters (e.g., under "Fundamentals," include P/E, EPS, etc.).
+
+2. **Filter Details Panel**:
+   - Appears on hover or click for each filter.
+   - Includes:
+     - A definition of the filter.
+     - An example of how it affects results.
+     - Visual aids like mini-charts or graphs.
+
+3. **Filter Search Bar**:
+   - Positioned prominently at the top.
+   - Supports auto-complete and tagging (e.g., "P/E under 20").
+
+4. **Dynamic Filter Preview**:
+   - Updates in real-time as users select filters.
+   - Shows the number of matching stocks and key metrics for context.
+
+---
+
+### **3. Results Page** (Stock Screener Section)
+
+This page should be added as an option in the top-level "Stock Screener" drop-down menu.
+
+#### **Purpose**
+
+- Display stocks matching selected filters with interactive sorting and visualization options.
+
+#### **Key Areas**
+
+1. **Filter Summary Panel**:
+   - Collapsible panel at the top or side.
+   - Displays applied filters with options to adjust or remove them inline.
+
+2. **Results Table**:
+   - Standard table format with sortable columns for key metrics (e.g., ticker, P/E, EPS).
+   - Include interactive features like:
+     - Inline charts for quick metric comparisons.
+     - Expandable rows to view detailed stock information.
+
+3. **Visualization Section**:
+   - Positioned below or as a toggleable area.
+   - Interactive charts (e.g., scatterplots, heatmaps) showing how stocks compare across selected metrics.
+
+4. **Save and Export Toolbar**:
+   - Buttons for saving current filter combinations as a preset.
+   - Export options (e.g., CSV, PDF).
+
+---
+
+### **4. AI Assistance Panel** (Stock Screener Section)
+
+This panel should be accessible from an option in the top-level "Stock Screener" drop-down menu.
+
+#### **Purpose**
+
+- Provide natural language interaction and real-time recommendations.
+
+#### **Key Areas**
+
+1. **Chat Interface**:
+   - Panel or widget on the right.
+   - Accepts user queries like "Find undervalued tech stocks with high EPS growth" and translates them into filters.
+
+2. **Recommendations Output**:
+   - Displays suggested filters and results inline.
+   - Includes plain-language explanations (e.g., "These stocks are undervalued based on their P/E ratios compared to the industry average").
+
+3. **Interactive Examples**:
+   - Pre-filled queries users can click to understand the tool's capabilities.
+
+---
+
+### **5. Onboarding Flow** (Stock Screener Section)
+
+This flow should be initiated from the top-level "Stock Screener" drop-down menu.
+
+#### **Purpose**
+
+- Guide new users through filter selection and the platform's key features.
+
+#### **Key Areas**
+
+1. **Welcome Screen**:
+   - Simple design introducing the tool’s purpose.
+   - Call-to-action buttons: "Learn the Basics," "Start Screening," or "Explore Presets."
+
+2. **Guided Steps**:
+   - Highlight essential features (e.g., filter library, results visualization).
+   - Include tooltips and progress indicators.
+
+3. **Quick Setup Questionnaire**:
+   - Ask users about their investment goals (e.g., "Are you looking for growth, value, or income?").
+   - Use responses to auto-suggest filters and presets.
+
+---
+
+### **6. Stock Detail Page** (Stock Screener Section)
+
+This page should be accessible via links in the "Results Page" or as an option in the top-level "Stock Screener" drop-down menu.
+
+#### **Purpose**
+
+- Provide in-depth information about a specific stock, enabling users to analyze its performance and metrics.
+
+#### **Key Areas**
+
+1. **Overview Section**:
+   - Display key details such as current price, P/E ratio, market cap, and dividend yield.
+   - Include a mini chart showing recent performance (e.g., last 1 month).
+
+2. **Performance Metrics Panel**:
+   - List critical metrics like EPS growth, ROE, ROA, and profitability ratios.
+   - Show visual indicators (e.g., sparklines, trend arrows) for quick interpretation.
+
+3. **News and Events Section**:
+   - Include recent news headlines and upcoming events (e.g., earnings report dates).
+   - Allow users to click through for more details.
+
+4. **Interactive Charting Tool**:
+   - Offer customizable charts for analyzing historical performance (e.g., price, volume, moving averages).
+
+5. **Peer Comparison Section**:
+   - Show how the stock compares to industry peers in key metrics.
+
+6. **Save and Add to Portfolio Button**:
+   - Let users save the stock to a watchlist or add it to a specific portfolio.
+
+---
+
+## General Design Requirements
+
+All pages and components will be implemented using **shadcn/ui** components for UI consistency and **Tailwind CSS** for efficient styling and responsiveness.
+
+1. **Consistency**:
+   - Use a cohesive design system (e.g., Material Design, Tailwind UI).
+   - Maintain uniform spacing, font sizes, and color schemes.
+
+2. **Responsiveness**:
+   - Ensure layouts adapt seamlessly across devices and screen sizes.
+
+3. **Accessibility**:
+   - Follow WCAG 2.2 AA standards (e.g., keyboard navigation, high-contrast mode).
+
+4. **Interactivity**:
+   - Use hover effects, animations, and transitions for a polished experience.
+   - Provide instant feedback for actions like filter selection or query submission.
+
+---
+
+This specification outlines the necessary details for creating mockups that address user needs while delivering a modern, intuitive stock screener experience. Let me know if additional details or adjustments are required.


### PR DESCRIPTION
Fixes #4

Rename the Trading menu to Screener and update child pages accordingly.

* **Navigation Configuration:**
  - Rename `paths.trading.stockScreener` to `/screener/results`
  - Rename `paths.trading.stockProfile` to `/screener/stock-detail/:ticker`
  - Rename `sidebarData.navMain[2].title` from `Trading` to `Screener`
  - Rename `sidebarData.navMain[2].items[0].title` from `Stock Screener` to `Screener Results`
  - Rename `sidebarData.navMain[2].items[1].title` from `Stock Profile` to `Stock Detail`
  - Rename `menuItems[0].label` from `Trading` to `Screener`
  - Rename `menuItems[0].children[0].label` from `Stock Screener` to `Screener Results`
  - Rename `menuItems[0].children[1].label` from `Stock Profile` to `Stock Detail`
  - Update `routes` paths for `StockScreenerPage` and `StockProfilePage`

* **App Component:**
  - Update import of `StockScreenerPage` to `ScreenerResultsPage`
  - Update import of `StockProfilePage` to `StockDetailPage`
  - Update `Routes` paths for `StockScreenerPage` and `StockProfilePage`

* **Page Components:**
  - Rename `StockScreenerPage` to `ScreenerResultsPage` and update component name
  - Rename `StockProfilePage` to `StockDetailPage` and update component name

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CambridgeMonorail/erisfy/pull/5?shareId=66691e83-6f4b-47da-9882-8213f248024c).