### PR TITLE
Update GitHub Actions to latest versions for upload and deploy pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,7 +88,7 @@ jobs:
       # Upload artifact for deployment
       - name: Upload to GitHub Pages artifact
         if: env.AUTHOR_NAME != 'Monorail Updater'
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: dist/apps/client # Path to your build output
 
@@ -103,4 +103,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         if: env.AUTHOR_NAME != 'Monorail Updater'
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Upgrade the GitHub Actions used for uploading and deploying pages to their latest versions for improved functionality and performance.