### PR TITLE
Enhance landing header

### DIFF
--- a/libs/landing/src/lib/components/header/Header.spec.tsx
+++ b/libs/landing/src/lib/components/header/Header.spec.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom'; // Import jest-dom for custom matchers
 import { Header } from './index';
 import { Home, User, Settings } from 'lucide-react';
+import { BrowserRouter } from 'react-router-dom';
 
 describe('Header', () => {
   const actionButtonsProps = [
@@ -11,20 +12,43 @@ describe('Header', () => {
   ];
 
   it('renders the logo and action buttons', () => {
-    render(<Header logoIcon={<Home />} actionButtonsProps={actionButtonsProps} />);
+    render(
+      <BrowserRouter>
+        <Header logoIcon={<Home />} actionButtonsProps={actionButtonsProps} />
+      </BrowserRouter>
+    );
     expect(screen.getByTestId('logo')).toBeInTheDocument();
     expect(screen.getAllByRole('button')).toHaveLength(3);
   });
 
   it('applies additional class names', () => {
-    render(<Header logoIcon={<Home />} actionButtonsProps={actionButtonsProps} className="custom-class" />);
+    render(
+      <BrowserRouter>
+        <Header logoIcon={<Home />} actionButtonsProps={actionButtonsProps} className="custom-class" />
+      </BrowserRouter>
+    );
     expect(screen.getByTestId('header')).toHaveClass('custom-class');
   });
 
   it('is responsive', () => {
-    render(<Header logoIcon={<Home />} actionButtonsProps={actionButtonsProps} />);
+    render(
+      <BrowserRouter>
+        <Header logoIcon={<Home />} actionButtonsProps={actionButtonsProps} />
+      </BrowserRouter>
+    );
     const header = screen.getByTestId('header');
     expect(header).toHaveClass('bg-primary', 'text-primary-foreground');
     expect(header).toHaveClass('flex', 'justify-between', 'p-4', 'items-center');
+  });
+
+  it('wraps logo and title in a link to the root of the site when linkToRoot is true', () => {
+    render(
+      <BrowserRouter>
+        <Header logoIcon={<Home />} actionButtonsProps={actionButtonsProps} title="MY APPLICATION" linkToRoot />
+      </BrowserRouter>
+    );
+    const linkElement = screen.getByRole('link', { name: /home/i });
+    expect(linkElement).toBeInTheDocument();
+    expect(linkElement).toHaveAttribute('href', '/');
   });
 });

--- a/libs/landing/src/lib/components/header/Header.stories.tsx
+++ b/libs/landing/src/lib/components/header/Header.stories.tsx
@@ -38,6 +38,11 @@ const meta: Meta<typeof Header> = {
       control: 'none',
       description: 'Icon to display as the logo',
     },
+    linkToRoot: {
+      name: 'Link to Root',
+      control: 'boolean',
+      description: 'Wrap the logo and title in a link to the root of the site',
+    },
   },
 };
 
@@ -56,6 +61,7 @@ export const Basic: Story = {
     centerContent: <div className="text-center">Center Content</div>,
     variant: 'primary',
     logoIcon: <Home />,
+    linkToRoot: false,
   },
 };
 
@@ -72,6 +78,7 @@ export const MultipleActionButtons: Story = {
       { icon: <Settings />, label: 'Settings' },
     ],
     variant: 'secondary',
+    linkToRoot: false,
   },
 };
 
@@ -89,6 +96,7 @@ export const CustomClassNames: Story = {
     ],
     className: 'bg-gray-800 text-white',
     variant: 'muted',
+    linkToRoot: false,
   },
 };
 
@@ -105,6 +113,7 @@ export const ResponsiveLayout: Story = {
       { icon: <Settings />, label: 'Settings' },
     ],
     variant: 'accent',
+    linkToRoot: false,
   },
 };
 
@@ -122,6 +131,7 @@ export const WithTitle: Story = {
     ],
     title: 'MY APPLICATION',
     variant: 'card',
+    linkToRoot: false,
   },
 };
 
@@ -139,6 +149,7 @@ export const WithCenterContent: Story = {
     ],
     centerContent: <div className="text-center">Center Content</div>,
     variant: 'destructive',
+    linkToRoot: false,
   },
 };
 
@@ -151,6 +162,7 @@ export const NoActionButtons: Story = {
   args: {
     actionButtonsProps: [],
     variant: 'sidebar',
+    linkToRoot: false,
   },
 };
 
@@ -168,5 +180,25 @@ export const DifferentLogo: Story = {
     ],
     logoIcon: <Home />,
     variant: 'primary',
+    linkToRoot: false,
+  },
+};
+
+/**
+ * Demonstrates the Header component with the logo and title wrapped in a link to the root of the site.
+ */
+export const WithLinkToRoot: Story = {
+  name: 'With Link to Root',
+  render: (args) => <Header {...args} />,
+  args: {
+    actionButtonsProps: [
+      { icon: <Home />, label: 'Home' },
+      { icon: <User />, label: 'User' },
+      { icon: <Settings />, label: 'Settings' },
+    ],
+    title: 'MY APPLICATION',
+    variant: 'primary',
+    logoIcon: <Home />,
+    linkToRoot: true,
   },
 };

--- a/libs/landing/src/lib/components/header/index.tsx
+++ b/libs/landing/src/lib/components/header/index.tsx
@@ -2,6 +2,7 @@ import { FC, ReactNode } from 'react';
 import { ActionButtons, ActionButtonProps } from '@erisfy/shadcnui-blocks';
 import { cn } from '@erisfy/shadcnui';
 import { cva, type VariantProps } from 'class-variance-authority';
+import { Link } from 'react-router-dom';
 
 // Define header variants using cva
 const headerVariants = cva('flex justify-between p-4 items-center', {
@@ -29,6 +30,7 @@ export type HeaderProps = {
   centerContent?: ReactNode;
   variant?: VariantProps<typeof headerVariants>['variant'];
   onButtonClick?: (index: number) => void;
+  linkToRoot?: boolean; // P42bd
 };
 
 /**
@@ -42,12 +44,22 @@ export const Header: FC<HeaderProps> = ({
   centerContent,
   variant,
   onButtonClick,
+  linkToRoot, // P42bd
 }) => {
   return (
     <header className={cn(headerVariants({ variant }), className)} data-testid="header">
       <div className="flex items-center space-x-2 flex-none" data-testid="logo">
-        {logoIcon}
-        {title && <div className='text-3xl font-semibold'>{title}</div>}
+        {linkToRoot ? ( // Pb819
+          <Link to="/" aria-label="Home">
+            {logoIcon}
+            {title && <div className='text-3xl font-semibold'>{title}</div>}
+          </Link>
+        ) : (
+          <>
+            {logoIcon}
+            {title && <div className='text-3xl font-semibold'>{title}</div>}
+          </>
+        )}
       </div>
       <div className="grow flex justify-start" data-testid="center-content">
         {centerContent}


### PR DESCRIPTION
Fixes #46

Enhance the `Header` component to include a link that navigates to the root of the site.

* **Header Component Changes:**
  - Wrap the logo and title in a `<Link>` component from `react-router-dom` that navigates to the root path (`/`).
  - Update the `HeaderProps` type to include an optional `linkToRoot` prop.
  - Conditionally render the `<Link>` component based on the `linkToRoot` prop.

* **Storybook Stories:**
  - Add examples of the logo and title being a link to the root of the site.
  - Update the `args` in the stories to include the `linkToRoot` prop.

* **Unit Tests:**
  - Add a test to check if the logo and title are wrapped in a link that navigates to the root of the site.
  - Update existing tests to account for the new `linkToRoot` prop.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CambridgeMonorail/erisfy/pull/47?shareId=d46869cf-302e-4648-9f88-7fefa1deeafe).