### PR TITLE
Document API mocking setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,38 @@ To learn how to theme your app using Shadcn UI and Tailwind CSS, please refer to
 
 To add a new component page to the routing in your React SPA, please refer to the detailed guide in [docs/adding-new-component-page.md](./docs/adding-new-component-page.md).
 
+## Enabling/Disabling API Mocks
+
+To enable or disable API mocks, follow these steps:
+
+1. Open the `.env` file in the `apps/client` directory.
+2. Set the `VITE_REACT_APP_USE_MOCKS` environment variable to `true` to enable mocks or `false` to disable them.
+
+```ini
+VITE_REACT_APP_USE_MOCKS=true
+```
+
+## Running Tests with MSW
+
+To run tests with MSW, follow these steps:
+
+1. Ensure that the mock server is set up in the `apps/client/src/mocks/server.ts` file.
+2. Import and start the mock server in your test setup file (`apps/client/src/test/setup.ts`).
+
+```typescript
+import { server } from '../mocks/server';
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+```
+
+3. Write your tests as usual, and MSW will intercept the API requests and return the mock responses.
+
+## Reference Documentation
+
+For detailed steps on setting up MSW and integrating API mocking in Erisfy, refer to the [Integrating API Mocking with MSW in Erisfy](./docs/specs/working/Integrating%20API%20Mocking%20with%20MSW%20in%20Erisfy.md) documentation.
+
 ## Contributing
 
 Contributions are welcome! Please open an issue or submit a pull request for any changes. For detailed guidelines on how to contribute, see [Contributing](./docs/CONTRIBUTING.md).

--- a/docs/specs/working/Integrating API Mocking with MSW in Erisfy.md
+++ b/docs/specs/working/Integrating API Mocking with MSW in Erisfy.md
@@ -197,3 +197,56 @@ If MSW is working correctly, it should return:
 ## Note
 
 Ensure that `VITE_USE_MOCKS` is set to 'true' in your environment variables to enable MSW. If `VITE_USE_MOCKS` is 'false' or undefined, MSW will not start.
+
+## How to Enable/Disable Mocks
+
+To enable or disable API mocks, follow these steps:
+
+1. Open the `.env` file in the `apps/client` directory.
+2. Set the `VITE_REACT_APP_USE_MOCKS` environment variable to `true` to enable mocks or `false` to disable them.
+
+```ini
+VITE_REACT_APP_USE_MOCKS=true
+```
+
+## How to Run Tests with MSW
+
+To run tests with MSW, follow these steps:
+
+1. Ensure that the mock server is set up in the `apps/client/src/mocks/server.ts` file.
+2. Import and start the mock server in your test setup file (`apps/client/src/test/setup.ts`).
+
+```typescript
+import { server } from '../mocks/server';
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+```
+
+3. Write your tests as usual, and MSW will intercept the API requests and return the mock responses.
+
+## Key Mock Endpoints
+
+Here are some key mock endpoints used in the project:
+
+- `GET /stocks/:id`: Returns mock stock data for a specific stock ID.
+- `GET /stocks`: Returns a list of mock stocks.
+
+## How to Mock Specific New APIs
+
+To add specific mocks for new APIs using MSW, follow these steps:
+
+1. Create mock data for the specific APIs in the `apps/client/src/mocks/data` directory. For example, you can add a new file like `apps/client/src/mocks/data/newApi.ts` to define the mock data for the new API.
+2. Update the `apps/client/src/mocks/browser.ts` file to include handlers for the new API endpoints. You can add new handlers using the `http` methods provided by MSW.
+3. Ensure that the mock worker is initialized in the `apps/client/src/main.tsx` file by calling the `initializeMockWorker` function if mocks are enabled.
+4. Update the `libs/api-client/src/clients/mockApiClient.ts` file to include methods for the new API endpoints, ensuring that the mock client returns the appropriate mock data.
+
+## Instructions for Developers on Adding Mocks for New Endpoints
+
+To add new API mocks using MSW in this project, follow these steps:
+
+1. Create mock data for the specific APIs in the `apps/client/src/mocks/data` directory. For example, you can add a new file like `apps/client/src/mocks/data/newApi.ts` to define the mock data for the new API.
+2. Update the `apps/client/src/mocks/browser.ts` file to include handlers for the new API endpoints. You can add new handlers using the `http` methods provided by MSW.
+3. Ensure that the mock worker is initialized in the `apps/client/src/main.tsx` file by calling the `initializeMockWorker` function if mocks are enabled.
+4. Update the `libs/api-client/src/clients/mockApiClient.ts` file to include methods for the new API endpoints, ensuring that the mock client returns the appropriate mock data.

--- a/mocks/README.md
+++ b/mocks/README.md
@@ -1,0 +1,50 @@
+# API Mock Endpoints
+
+This document provides an overview of the key mock endpoints used in the project. These endpoints are implemented using Mock Service Worker (MSW) to simulate API responses for development and testing purposes.
+
+## Key Mock Endpoints
+
+### Stocks API
+
+- **GET /stocks/:id**
+  - Description: Returns mock stock data for a specific stock ID.
+  - Example Response:
+    ```json
+    {
+      "id": "1",
+      "symbol": "MOCK-AAPL",
+      "price": 150
+    }
+    ```
+
+- **GET /stocks**
+  - Description: Returns a list of mock stocks.
+  - Example Response:
+    ```json
+    [
+      {
+        "id": "1",
+        "symbol": "MOCK-AAPL",
+        "price": 150
+      },
+      {
+        "id": "2",
+        "symbol": "MOCK-MSFT",
+        "price": 280
+      }
+    ]
+    ```
+
+## Adding New Mock Endpoints
+
+To add new mock endpoints, follow these steps:
+
+1. **Create Mock Data**: Define the mock data for the new API in the `apps/client/src/mocks/data` directory. For example, create a new file like `newApi.ts` to define the mock data.
+
+2. **Update Handlers**: Update the `apps/client/src/mocks/browser.ts` file to include handlers for the new API endpoints. Use the `http` methods provided by MSW to define the handlers.
+
+3. **Initialize Mock Worker**: Ensure that the mock worker is initialized in the `apps/client/src/main.tsx` file by calling the `initializeMockWorker` function if mocks are enabled.
+
+4. **Update Mock API Client**: Update the `libs/api-client/src/clients/mockApiClient.ts` file to include methods for the new API endpoints, ensuring that the mock client returns the appropriate mock data.
+
+By following these steps, you can add specific mocks for new APIs using MSW in your project. This will help you test and develop your application without relying on real API endpoints.


### PR DESCRIPTION
Fixes #69

Add documentation for API mocking setup and usage in the project.

* **README.md**:
  - Add instructions on enabling/disabling API mocks.
  - Add instructions on running tests with MSW.
  - Reference `docs/specs/working/Integrating API Mocking with MSW in Erisfy.md`.

* **docs/specs/working/Integrating API Mocking with MSW in Erisfy.md**:
  - Add sections on enabling/disabling mocks, running tests with MSW, key mock endpoints, and how to mock specific new APIs.
  - Add instructions for developers on adding mocks for new endpoints.

* **mocks/README.md**:
  - Document key mock endpoints.
  - Provide steps for adding new mock endpoints.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CambridgeMonorail/erisfy/pull/73?shareId=5bc20ce4-586a-46ff-ae2f-7a84bb76a367).