### PR TITLE
Add exit condition for Monorail Updater in deployment script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,7 @@ jobs:
           if [ "$AUTHOR" = "Monorail Updater" ]; then
             echo "Commit author is Monorail Updater. Exiting..."
             exit 0
+          fi
 
       # Set up Node.js
       - name: Setup Node.js


### PR DESCRIPTION
Implement an exit condition in the deployment script to prevent further execution if the commit author is the Monorail Updater.