### PR TITLE
Enhance AIPoweredMarketOverview to use News Story Carousel

### DIFF
--- a/apps/client/src/app/components/AIPoweredMarketOverview.tsx
+++ b/apps/client/src/app/components/AIPoweredMarketOverview.tsx
@@ -6,10 +6,9 @@ import {
   CardContent, 
   Badge,
   Separator,
-  ScrollArea, 
   cn
 } from '@erisfy/shadcnui';
-import { Spinner } from '@erisfy/shadcnui-blocks';
+import { Spinner, NewsCarousel } from '@erisfy/shadcnui-blocks';
 import { AlertCircle, TrendingDown } from 'lucide-react';
 import { MarketStory } from '@erisfy/api';
 import { useMarketInsights } from '../hooks/useMarketInsights';
@@ -137,16 +136,7 @@ export const AIPoweredMarketOverview: FC<AIPoweredMarketOverviewProps> = ({
         </div>
       </CardHeader>
       <CardContent className="p-4">
-        <ScrollArea className="h-[800px] pr-4">
-          <div className="space-y-4">
-            {insights.stories.map((story, index) => (
-              <MarketStoryCard 
-                key={`${story.market_sector}-${index}`} 
-                story={story} 
-              />
-            ))}
-          </div>
-        </ScrollArea>
+        <NewsCarousel stories={insights.stories} />
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
Fixes #87

Enhance the `AIPoweredMarketOverview` component to use the `NewsCarousel` component from the `shadcnui-blocks` library.

* Import `NewsCarousel` from `@erisfy/shadcnui-blocks`.
* Replace the `ScrollArea` component with the `NewsCarousel` component in the `AIPoweredMarketOverview` component.
* Map `insights.stories` to the `stories` prop of the `NewsCarousel` component.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CambridgeMonorail/erisfy/pull/97?shareId=2a17dfe2-5f6b-4958-8dcc-e3e958298f97).